### PR TITLE
Finish separating the SimplSAMLPhp code into a BLT plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ following tasks:
    Note:
        The ``source:build:simplesamlphp-config`` command is strictly for local
        use, and because the command overwrites vendor files, running the
-       command will make not make any changes that are visible to Git.
+       command will not make any changes that are visible to Git.
 
 SimpleSAMLphp should now be ready for testing in your local environment. When
 you are ready to test in an Acquia Cloud environment, commit your configuration

--- a/scripts/simplesamlphp/gitignore.txt
+++ b/scripts/simplesamlphp/gitignore.txt
@@ -1,0 +1,160 @@
+.gitignore
+log
+
+!config/.gitkeep
+!metadata/.gitkeep
+
+# https://www.gitignore.io/api/osx,windows,linux,netbeans,sublimetext,composer,phpstorm,vagrant
+# Created by https://www.gitignore.io
+
+# Created by https://www.gitignore.io
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+### Linux ###
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+### Eclipse ###
+.project
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+.nb-gradle/
+
+
+### SublimeText ###
+# cache files for sublime text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+
+### Composer ###
+composer.phar
+vendor/
+
+# Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+# composer.lock
+
+
+### PhpStorm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+
+### Vagrant ###
+.vagrant/

--- a/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
+++ b/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
@@ -71,6 +71,20 @@ class SimpleSamlPhpCommand extends BltTasks {
   }
 
   /**
+   * Adds simplesamlphp_auth as a dependency.
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  protected function requireModule() {
+    $this->say('Adding SimpleSAMLphp Auth module as a dependency...');
+    $package_options = [
+      'package_name' => 'drupal/simplesamlphp_auth',
+      'package_version' => '^3.0',
+    ];
+    $this->invokeCommand('internal:composer:require', $package_options);
+  }
+
+  /**
    * Copies configuration templates from SimpleSamlPHP to the repo root.
    *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException

--- a/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
+++ b/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
@@ -62,7 +62,6 @@ class SimpleSamlPhpCommand extends BltTasks {
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function initializeSimpleSamlPhp() {
-    $this->requireModule();
     $this->initializeConfig();
     $this->setSimpleSamlPhpInstalled();
     $this->symlinkDocrootToLibDir();

--- a/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
+++ b/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
@@ -18,7 +18,7 @@ class SimpleSamlPhpCommand extends BltTasks {
    *
    * @var string
    */
-  protected $bltRoot;
+  protected $pluginRoot;
 
   /**
    * Repo root.
@@ -47,7 +47,7 @@ class SimpleSamlPhpCommand extends BltTasks {
    * @hook init
    */
   public function initialize() {
-    $this->bltRoot = $this->getConfigValue('blt.root');
+    $this->pluginRoot = $this->getConfigValue('blt.root') . '/../blt-simplesamlphp';
     $this->repoRoot = $this->getConfigValue('repo.root');
     $this->deployDir = $this->getConfigValue('deploy.dir');
     $this->formatter = new FormatterHelper();
@@ -96,7 +96,7 @@ class SimpleSamlPhpCommand extends BltTasks {
     $result = $this->taskFileSystemStack()
       ->copy("{$this->repoRoot}/vendor/simplesamlphp/simplesamlphp/config-templates/authsources.php", "${destinationDirectory}/authsources.php", TRUE)
       ->copy("{$this->repoRoot}/vendor/simplesamlphp/simplesamlphp/config-templates/config.php", "${destinationDirectory}/config.php", TRUE)
-      ->copy("{$this->bltRoot}/scripts/simplesamlphp/acquia_config.php", "${destinationDirectory}/acquia_config.php", TRUE)
+      ->copy("{$this->pluginRoot}/scripts/simplesamlphp/acquia_config.php", "${destinationDirectory}/acquia_config.php", TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
     if (!$result->wasSuccessful()) {
@@ -143,7 +143,7 @@ class SimpleSamlPhpCommand extends BltTasks {
     }
 
     $result = $this->taskFileSystemStack()
-      ->copy("{$this->bltRoot}/scripts/simplesamlphp/gitignore.txt", "{$this->deployDir}/vendor/simplesamlphp/simplesamlphp/.gitignore", TRUE)
+      ->copy("{$this->pluginRoot}/scripts/simplesamlphp/gitignore.txt", "{$this->deployDir}/vendor/simplesamlphp/simplesamlphp/.gitignore", TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
 
@@ -212,7 +212,7 @@ class SimpleSamlPhpCommand extends BltTasks {
     }
 
     $result = $this->taskFileSystemStack()
-      ->copy("{$this->bltRoot}/scripts/simplesamlphp/gitignore.txt", "{$this->repoRoot}/vendor/simplesamlphp/simplesamlphp/.gitignore", TRUE)
+      ->copy("{$this->pluginRoot}/scripts/simplesamlphp/gitignore.txt", "{$this->repoRoot}/vendor/simplesamlphp/simplesamlphp/.gitignore", TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
     if (!$result->wasSuccessful()) {
@@ -259,7 +259,7 @@ class SimpleSamlPhpCommand extends BltTasks {
    */
   protected function addHtaccessPatch() {
     $this->taskFilesystemStack()
-      ->copy($this->bltRoot . "/scripts/simplesamlphp/htaccess-saml.patch",
+      ->copy("{$this->pluginRoot}/scripts/simplesamlphp/htaccess-saml.patch",
         $this->repoRoot . "/patches/htaccess-saml.patch")
       ->run();
     $composer_json = json_decode(file_get_contents("{$this->repoRoot}/composer.json"));

--- a/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
+++ b/src/Blt/Plugin/Commands/SimpleSamlPhpCommand.php
@@ -71,20 +71,6 @@ class SimpleSamlPhpCommand extends BltTasks {
   }
 
   /**
-   * Adds simplesamlphp_auth as a dependency.
-   *
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
-   */
-  protected function requireModule() {
-    $this->say('Adding SimpleSAMLphp Auth module as a dependency...');
-    $package_options = [
-      'package_name' => 'drupal/simplesamlphp_auth',
-      'package_version' => '^3.0',
-    ];
-    $this->invokeCommand('internal:composer:require', $package_options);
-  }
-
-  /**
    * Copies configuration templates from SimpleSamlPHP to the repo root.
    *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException


### PR DESCRIPTION
When testing the `blt recipes:simplesamlphp:init` command, I ran into several errors. It seems that the job of moving this code from BLT core into a separate plugin was never quite finished.

With the changes here, I can run `blt recipes:simplesamlphp:init` without errors and get to the next step of the process.