### PR TITLE
Update htaccess-saml.patch

### DIFF
--- a/scripts/simplesamlphp/htaccess-saml.patch
+++ b/scripts/simplesamlphp/htaccess-saml.patch
@@ -5,7 +5,7 @@ index 27e18a0..03eabf5 100644
 @@ -149,6 +149,8 @@ AddEncoding gzip svgz
    RewriteCond %{REQUEST_URI} !/core/[^/]*\.php$
    # Allow access to test-specific PHP files:
-   RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?.php
+   RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?\.php
 +  # Allow access to simplesaml paths.
 +  RewriteCond %{REQUEST_URI} !^/simplesaml
    # Allow access to Statistics module's custom front controller.


### PR DESCRIPTION
Updated the patch file to include the escape for the period. The escaped period is introduced in Drupal 9.1.

Drupal's .htaccess file as reference.
https://git.drupalcode.org/project/drupal/-/blob/9.2.x/.htaccess#L141 